### PR TITLE
Support `JSON.stringify` of objects

### DIFF
--- a/inst/js/cookie_input.js
+++ b/inst/js/cookie_input.js
@@ -17,6 +17,9 @@ function getCookies(){
 
 Shiny.addCustomMessageHandler('cookie-set', function(msg){
   try {
+    if (typeof msg.value == "object") {
+      msg.value = JSON.stringify(msg.value)
+    }
     Cookies.set(msg.name, msg.value, msg.attributes);
     let cookie = Cookies.get(msg.name);
     if (cookie === undefined) {


### PR DESCRIPTION
Hi @jonthegeek!
I was wondering if `cookies` can support `JSON.stringify` of objects passed as the `cookie_value`? This will allow for a simplification of usage where a single app cookie object with a bunch of values can be written/read.